### PR TITLE
hotfix-1.0.1 23.11.08 

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -270,8 +270,11 @@ class ImportInspectionViewSet(viewsets.ModelViewSet):
 
 
 # Assembly Instruction API
+# 조립완료 처리 시 Pagination으로 인해 데이터를 10개 밖에 불러오지 못하여 Update가 안되는 문제가 있었습니다.
+# Pagination에서 page_size를 1000으로 설정하여 해결하였습니다.
+# 2023.11.08 수정
 class AssemblyInstructionPagination(PageNumberPagination):
-    page_size = 10
+    page_size = 1000
     page_query_param = 'page'
     max_page_size = 10000000000
 


### PR DESCRIPTION
Views.py에서 AssemplyInstruction API GET요청 시 page_size로 인해 조립대기 상태를 조립완료 상태로 변경을 page_size(10개)에 맞게 PUT 요청을 하다보니 10개가 넘어가는 데이터를 작업지시 할 경우 10개만 처리하여 나머지 부분들이 계속 작업지시가 있는 문제가 발생하였고, page_size를 1000으로 설정함으로써 해결.