### PR TITLE
v1.0.8-beta2

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -65,7 +65,9 @@ class ExternalInventoryPagination(PageNumberPagination):
 # 23.11.16 이성범 수정.
 # get_queryset에서 filter를 state 와 page_size로 창고조회 페이지에서 남은부품, 입고 상태만 보여줄 수 있도록 함. (= 조립완료 상태일 때는 현재수량 0)
 class ExternalInventoryViewSet(viewsets.ModelViewSet):
-    queryset = ExternalInventory.objects.all().order_by('inputDateTime')
+    # 24.01.22 이성범 수정
+    # external_inventory에서 데이터를 불러올때 입고날짜 순서가 아닌 lotNo순으로 부품을 정렬하여 부품을 불러오도록 수정
+    queryset = ExternalInventory.objects.all().order_by('lotNo')
     serializer_class = ExternalInventorySerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_fields = ('partNumber', 'lotNo', 'stock', 'inputDateTime', 'user_id', 'date_of_receipt')


### PR DESCRIPTION
Inventory 기본 API요청 쿼리셋에서 order_by를 InputDate가 아닌 lotNo순으로 하도록 변경. 남은 부품을 불러올때 lotNo가 작은 순부터 불러오도록 해야 가장 오래된 부품을 처리하는 업체의 방식 적용.